### PR TITLE
allow use of newer versions of webdriverjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "async": "~0.2.10",
     "mocha": "~1.18.0",
-    "webdriverjs": "~1.3.x",
+    "webdriverjs": "~1.5.x",
     "saucelabs": "~0.1.1",
     "sauce-tunnel": "~2.0.1",
     "selenium-standalone": "~2.40.0-2.9.0",


### PR DESCRIPTION
webdriverjs is now at version 1.5 , so let's use the new version
