### PR TITLE
Added support for jasmine with grunt-jasmine-node code integration.

### DIFF
--- a/tasks/webdriver.js
+++ b/tasks/webdriver.js
@@ -1,5 +1,4 @@
-var Mocha         = require('mocha'),
-    SauceLabs     = require('saucelabs'),
+var SauceLabs     = require('saucelabs'),
     SauceTunnel   = require('sauce-tunnel'),
     selenium      = require('selenium-standalone'),
     webdriverjs   = require('webdriverjs'),
@@ -18,11 +17,13 @@ var Mocha         = require('mocha'),
 
 module.exports = function(grunt) {
 
-    grunt.registerMultiTask('webdriver', 'run WebdriverJS tests with Mocha', function() {
+    grunt.registerMultiTask('webdriver', 'run WebdriverJS tests', function() {
 
         var that = this,
             done = this.async(),
             base = process.cwd(),
+            testSuiteType = 'mocha',
+            testSuite = null,
             options = this.options({
                 reporter: 'spec',
                 ui: 'bdd',
@@ -33,7 +34,10 @@ module.exports = function(grunt) {
                 updateSauceJob: false,
                 output: null,
                 quiet: false,
-                nospawn: false
+                nospawn: false,
+                testSuite: {
+                    type: testSuiteType
+                },
             }),
             capabilities = deepmerge(options,this.data.options || {}),
             tunnelIdentifier = options['tunnel-identifier'] || (capabilities.desiredCapabilities ? capabilities.desiredCapabilities['tunnel-identifier'] : null) || null,
@@ -49,13 +53,73 @@ module.exports = function(grunt) {
         GLOBAL.browser = webdriverjs.remote(capabilities);
 
         /**
-         * initialize Mocha
+         * initialize test suite
          */
-        var mocha = new Mocha(options);
+        if ( capabilities.hasOwnProperty( 'testSuite' ) && capabilities.testSuite.type === 'jasmine' ) {
+            // Jasmine
+            testSuiteType = 'jasmine';
+            testSuite = require('jasmine-node');
+            var specFolders = grunt.file.expand({
+                filter: function( filepath ) {
+                  return grunt.file.isDir( filepath );
+                }
+            }, base + '/' + this.data.tests);
 
-        grunt.file.expand(grunt.file.expand(base + '/' + this.data.tests)).forEach(function(file) {
-            mocha.addFile(file);
-        });
+            // Config jasmine options
+            var jasmineOptions = {
+                specFolders: specFolders,
+                projectRoot: '',
+                match: '.',
+                matchall: false,
+                specNameMatcher: 'spec',
+                helperNameMatcher: 'helpers',
+                extensions: 'js',
+                showColors: true,
+                includeStackTrace: true,
+                useHelpers: false,
+                    teamcity: false,
+                verbose: false,
+                jUnit: {
+                    report: false,
+                    savePath: "./reports/",
+                    useDotNotation: true,
+                    consolidate: true
+                },
+                growl: false
+            };
+            jasmineOptions = deepmerge(jasmineOptions, capabilities.testSuite.args || {});
+
+            if (jasmineOptions.projectRoot) {
+                jasmineOptions.specFolders.push(jasmineOptions.projectRoot);
+            }
+            var regExpSpec = new RegExp(jasmineOptions.match + (jasmineOptions.matchall ? "" : jasmineOptions.specNameMatcher + "\\." ) + "(" + jasmineOptions.extensions + ")$", 'i');
+
+            if (jasmineOptions.useHelpers) {
+                this.filesSrc.forEach(function(path) {
+                    testSuite.loadHelpersInFolder(path, new RegExp(jasmineOptions.helperNameMatcher + "?\\.(" + jasmineOptions.extensions + ")$", 'i'));
+                });
+            }
+
+            jasmineOptions = {
+                specFolders: jasmineOptions.specFolders,
+                isVerbose: grunt.verbose ? true : jasmineOptions.verbose,
+                showColors: jasmineOptions.showColors,
+                teamcity: jasmineOptions.teamcity,
+                useRequireJs: jasmineOptions.useRequireJs,
+                regExpSpec: regExpSpec,
+                junitreport: jasmineOptions.jUnit,
+                includeStackTrace: jasmineOptions.includeStackTrace,
+                growl: jasmineOptions.growl
+            };
+        } else {
+            // Mocha
+            var Mocha = require('mocha');
+            testSuite = new Mocha(options);
+
+            grunt.file.expand(grunt.file.expand(base + '/' + this.data.tests)).forEach(function(file) {
+                testSuite.addFile(file);
+            });
+		}
 
         /**
          * hook process.stdout.write to save reporter output into file
@@ -235,12 +299,29 @@ module.exports = function(grunt) {
             },
 
             /**
-             * run mocha tests
+             * run tests
              */
             function(args,callback) {
-                grunt.log.debug('run mocha tests');
+                grunt.log.debug('run tests with ' + testSuiteType);
 
-                mocha.run(next.bind(callback));
+                if (testSuiteType === 'jasmine') {
+                    // jasmine
+                    var onJasmineComplete = function(runner, log) {
+                        testSuite.getGlobal( ).jasmine.currentEnv_ = undefined;
+                        callback(null, runner.results( ).failedCount);
+                    };
+
+                    jasmineOptions.onComplete = onJasmineComplete;
+
+                    // for jasmine-node 1.3
+                    testSuite.executeSpecsInFolder(jasmineOptions);
+                    // for jasmine-node 2
+                    // jasmineOptions.watchFolders = [ ];
+                    // testSuite.run( jasmineOptions );
+                } else {
+                    // mocha
+                    testSuite.run(next.bind(callback));
+                }
             },
 
             /**


### PR DESCRIPTION
I think this PR could be interesting for other people. A user can configure the grunt task to run tests with jasmine instance of mocha. User must install 'jasmine-node' as project dependency. 

Configuration is inside 'testSuite' option. For example:

```
webdriver:
{
  options:
  {
    desiredCapabilities:
    {
      browserName: "phantomjs"
    },
    testSuite:
    {
      type: "jasmine",
      args:
      {
        forceExit: true,
        match: ".",
        matchall: false,
        extensions: "js",
        specNameMatcher: "spec",
        verbose: true,
      }
    }
  },
  e2e:
  {
    tests: [ "./test/e2e/" ]
  }
}
```

Mocha is still the default option.

This PR is based on grunt-jasmine-node code: https://github.com/jasmine-contrib/grunt-jasmine-node
