### PR TITLE
Bumped selenium-standalone version to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "webdriverio": "^2.3.0",
     "saucelabs": "^0.1.1",
     "sauce-tunnel": "^2.0.1",
-    "selenium-standalone": "^2.41.0-2.9.0-1",
+    "selenium-standalone": "^4.2.0",
     "deepmerge": "^0.2.7",
     "hooker": "^0.2.3",
     "path": "^0.4.9",


### PR DESCRIPTION
Feel free to use it as a base, I wanted to try out webdriver with phantomjs, and I couldn't get it to work with selenium 2.44, so I bumped selenium-standalone in order to be able to use 2.45.

--

Added the following options to the task:
	- seleniumOptions: options to start selenium
	- seleniumInstallOptions: install options

If the drivers are missing, the task will
call selenium.install.

Now using the callback option of selenium.start().