### PR TITLE
Add webdriverio core package as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "webdriverio": "^3.2.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": "~0.4.2",
+    "webdriverio": "^3.2.1"
   },
   "keywords": [
     "grunt",


### PR DESCRIPTION
When `webdriverio` package is missing, it would be better to get a warning from npm during `npm install` rather than silly error in your tests:
```
Error: Cannot find module '<path>/node_modules/webdriverio/bin/wdio'
```