### PR TITLE
Use wdioBin from options

### DIFF
--- a/tasks/webdriver.js
+++ b/tasks/webdriver.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
             grunt.util.error('No config file found');
         }
 
-        var args = process.execArgv.concat([wdioBin, opts.configFile]).concat(dargs(opts, {
+        var args = process.execArgv.concat([opts.wdioBin, opts.configFile]).concat(dargs(opts, {
             excludes: ['nodeBin', 'wdioBin'],
             keepCamelCase: true
         }));


### PR DESCRIPTION
If you are checking existence of `options.wdio` [here](https://github.com/webdriverio/grunt-webdriver/blob/master/tasks/webdriver.js#L25) you should use it in exec.

Fixes #76