### PR TITLE
Clear eval argv to avoid cyclic runs

### DIFF
--- a/tasks/webdriver.js
+++ b/tasks/webdriver.js
@@ -5,6 +5,20 @@ var path = require('path'),
     dargs = require('dargs'),
     deepmerge = require('deepmerge');
 
+function getExecArgv() {
+  var execArgv = process.execArgv
+  // Remove the -e switch to avoid fork bombing ourselves.
+  // https://github.com/nodejs/node/blob/v5.9.0/lib/child_process.js#L36-L43
+  if (process._eval != null) {
+    var index = execArgv.lastIndexOf(process._eval);
+    if (index > 0) {
+      execArgv = execArgv.slice();
+      execArgv.splice(index - 1, 2);
+    }
+  }
+  return execArgv;
+}
+
 module.exports = function(grunt) {
 
     grunt.registerMultiTask('webdriver', 'run wdio test runner', function() {
@@ -33,7 +47,7 @@ module.exports = function(grunt) {
             grunt.util.error('No config file found');
         }
 
-        var args = process.execArgv.concat([opts.wdioBin, opts.configFile]).concat(dargs(opts, {
+        var args = getExecArgv().concat([opts.wdioBin, opts.configFile]).concat(dargs(opts, {
             excludes: ['nodeBin', 'wdioBin'],
             keepCamelCase: true
         }));

--- a/tasks/webdriver.js
+++ b/tasks/webdriver.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
             grunt.util.error('No config file found');
         }
 
-        var args = process.execArgv.concat([wdioBin, opts.configFile]).concat(dargs(opts, {
+        var args = process.execArgv.concat([opts.wdioBin, opts.configFile]).concat(dargs(opts, {
             excludes: ['nodeBin', 'wdioBin'],
             keepCamelCase: true
         }));


### PR DESCRIPTION
Some people trying to run grunt using the following expression
```sh
node -e "require('grunt').tasks(['test'])"
```
This is good because it makes possible to run grunt without installation a separate `grunt-cli` package. [Github search results](https://github.com/search?l=json&q=require%28%27grunt%27%29.tasks%28%29&type=Code&utf8=✓) prove that it is very popular practice. 

But this task runs child process and copies all exec arguments to new process, including `-e`. I brought the solution from the [node.js sources](https://github.com/nodejs/node/blob/v5.9.0/lib/child_process.js#L36-L43) where the same thing would happen.

P.S. this pull-request contains the commit from #79, because otherwise you will get merge conflicts, they have changes on the same line.